### PR TITLE
fix: change replaces the Chinese term "巡检" with the English word "inspection"

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ The effective execution path is:
 
 ## Core self-check
 
-The old scout-style巡检 loop is replaced by a core-owned self-check loop. It reuses doctor-style validation for configured agents and can run extra commands from config. When a check fails, the runtime creates a repair task and wakes the configured top-level agent early.
+The old scout-style inspection loop is replaced by a core-owned self-check loop. It reuses doctor-style validation for configured agents and can run extra commands from config. When a check fails, the runtime creates a repair task and wakes the configured top-level agent early.
 
 ## Runtime boundaries
 


### PR DESCRIPTION
cc: @marrow-bot 审查一下，看看语句通不通顺。不合理的帮我改一下，合理的话帮我合了