### PR TITLE
子agent medium模型

### DIFF
--- a/marrow_core/caster.py
+++ b/marrow_core/caster.py
@@ -59,6 +59,7 @@ def cast_roles_to_workspace(
 
     for output in outputs:
         full_path = Path(target_config.output_dir) / output.path
+        content = _disable_subagent_question_permission(output.content)
         try:
             full_path.parent.mkdir(parents=True, exist_ok=True)
         except PermissionError:
@@ -79,7 +80,7 @@ def cast_roles_to_workspace(
             continue
 
         try:
-            full_path.write_text(output.content, encoding="utf-8")
+            full_path.write_text(content, encoding="utf-8")
         except PermissionError:
             _record_permission_skip(result, full_path)
             continue
@@ -112,6 +113,22 @@ def _clear_generated_outputs(agents_dir: Path, result: CastResult) -> None:
             _record_permission_skip(result, path)
         except OSError as exc:
             _record_error(result, path, exc)
+
+
+def _disable_subagent_question_permission(content: str) -> str:
+    if not content.startswith("---\n"):
+        return content
+
+    parts = content.split("---\n", 2)
+    if len(parts) != 3:
+        return content
+
+    frontmatter = parts[1]
+    if "mode: subagent" not in frontmatter:
+        return content
+
+    sanitized_frontmatter = frontmatter.replace('  "question": allow\n', "")
+    return f"---\n{sanitized_frontmatter}---\n{parts[2]}"
 
 
 def _prune_empty_dirs(root: Path, result: CastResult) -> None:

--- a/marrow_core/contracts.py
+++ b/marrow_core/contracts.py
@@ -41,8 +41,7 @@ SYNCED_ROLE_FILES = TOP_LEVEL_AGENTS + STEWARDS + LEADERS + EXPERTS
 
 ROLE_MODEL_TIERS = {
     "curator": "high",
-    **dict.fromkeys(STEWARDS + LEADERS, "medium"),
-    **dict.fromkeys(EXPERTS, "low"),
+    **dict.fromkeys(STEWARDS + LEADERS + EXPERTS, "medium"),
 }
 
 ROLE_PATHS = {

--- a/roles/experts/analyst.md
+++ b/roles/experts/analyst.md
@@ -5,7 +5,7 @@ description: >-
   dependency analysis for a bounded question.
 role: subagent
 model:
-  tier: low
+  tier: medium
 capabilities:
   - basic
 ---

--- a/roles/experts/coder.md
+++ b/roles/experts/coder.md
@@ -5,7 +5,7 @@ description: >-
   the task is already well-defined.
 role: subagent
 model:
-  tier: low
+  tier: medium
 capabilities:
   - basic
 ---

--- a/roles/experts/filer.md
+++ b/roles/experts/filer.md
@@ -5,7 +5,7 @@ description: >-
   workspace hygiene tasks with strong caution around destructive actions.
 role: subagent
 model:
-  tier: low
+  tier: medium
 capabilities:
   - basic
 ---

--- a/roles/experts/git-ops.md
+++ b/roles/experts/git-ops.md
@@ -5,7 +5,7 @@ description: >-
   a parent role wants a focused git-oriented worker.
 role: subagent
 model:
-  tier: low
+  tier: medium
 capabilities:
   - basic
 ---

--- a/roles/experts/researcher.md
+++ b/roles/experts/researcher.md
@@ -5,7 +5,7 @@ description: >-
   and comparative findings for a specific question.
 role: subagent
 model:
-  tier: low
+  tier: medium
 capabilities:
   - basic
 ---

--- a/roles/experts/tester.md
+++ b/roles/experts/tester.md
@@ -5,7 +5,7 @@ description: >-
   reports concrete regression evidence.
 role: subagent
 model:
-  tier: low
+  tier: medium
 capabilities:
   - basic
 ---

--- a/roles/experts/writer.md
+++ b/roles/experts/writer.md
@@ -5,7 +5,7 @@ description: >-
   text for a bounded output target.
 role: subagent
 model:
-  tier: low
+  tier: medium
 capabilities:
   - basic
 ---

--- a/tests/test_agent_layout.py
+++ b/tests/test_agent_layout.py
@@ -54,13 +54,14 @@ def test_role_inventory_matches_contract():
 
 def test_role_model_tiers_match_expected_inventory():
     assert ROLE_MODEL_TIERS["curator"] == "high"
-    assert ROLE_MODEL_TIERS["delivery"] == "medium"
-    assert ROLE_MODEL_TIERS["portfolio"] == "medium"
-    assert ROLE_MODEL_TIERS["context"] == "medium"
-    assert ROLE_MODEL_TIERS["acceptance"] == "medium"
-    assert ROLE_MODEL_TIERS["hygiene"] == "medium"
-    assert ROLE_MODEL_TIERS["memory"] == "medium"
-    assert ROLE_MODEL_TIERS["coder"] == "low"
+    for role in STEWARDS + LEADERS + EXPERTS:
+        assert ROLE_MODEL_TIERS[role] == "medium"
+
+
+def test_role_files_match_contract_model_tiers():
+    for role, tier in ROLE_MODEL_TIERS.items():
+        text = _role_file(role).read_text(encoding="utf-8")
+        assert f"model:\n  tier: {tier}" in text
 
 
 def test_role_inventory_groups_are_stable():

--- a/tests/test_caster.py
+++ b/tests/test_caster.py
@@ -33,23 +33,26 @@ def _write_roles_toml(core_dir: Path) -> None:
     )
 
 
-def _write_role(role_dir: Path, name: str, *, description: str = "Role") -> None:
-    (role_dir / f"{name}.md").write_text(
-        textwrap.dedent(
-            f"""
-            ---
-            name: {name}
-            description: {description}
-            role: subagent
-            model:
-              tier: medium
-            ---
-            You are {name}.
-            """
-        ).strip()
-        + "\n",
-        encoding="utf-8",
-    )
+def _write_role(
+    role_dir: Path,
+    name: str,
+    *,
+    description: str = "Role",
+    tier: str = "medium",
+    capabilities: str | None = None,
+) -> None:
+    lines = [
+        "---",
+        f"name: {name}",
+        f"description: {description}",
+        "role: subagent",
+        "model:",
+        f"  tier: {tier}",
+    ]
+    if capabilities:
+        lines.extend(["capabilities:", f"  - {capabilities}"])
+    lines.extend(["---", f"You are {name}.", ""])
+    (role_dir / f"{name}.md").write_text("\n".join(lines), encoding="utf-8")
 
 
 def test_cast_roles_to_workspace_generates_opencode_outputs(tmp_path: Path) -> None:
@@ -116,6 +119,27 @@ def test_cast_roles_to_workspace_preserves_custom_role_files(tmp_path: Path) -> 
     cast_roles_to_workspace(str(core_dir), str(workspace))
 
     assert (agents_dir / "custom-local.md").read_text(encoding="utf-8") == "custom"
+
+
+def test_cast_roles_to_workspace_disables_subagent_question_permission(tmp_path: Path) -> None:
+    core_dir = tmp_path / "core"
+    workspace = tmp_path / "workspace"
+    role_dir = core_dir / "roles"
+    role_dir.mkdir(parents=True)
+    (workspace / ".opencode" / "agents").mkdir(parents=True)
+    _write_roles_toml(core_dir)
+    _write_role(role_dir, "helper", tier="medium", capabilities="all")
+
+    result = cast_roles_to_workspace(str(core_dir), str(workspace))
+
+    target = workspace / ".opencode" / "agents" / "helper.md"
+    assert result == CastResult(written=[target], skipped_permission=[], errors=[])
+    content = target.read_text(encoding="utf-8")
+    assert "mode: subagent" in content
+    assert "model: model-medium" in content
+    assert '"bash": allow' in content
+    assert '"task": allow' in content
+    assert '"question": allow' not in content
 
 
 def test_cast_roles_to_workspace_skips_permission_denied_unlink(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Unify sub-agent model tier to `medium` and disable `ask` permissions for all sub-agents.

<div><a href="https://cursor.com/agents/bc-ca500a1c-02d9-4e45-97ac-0425c8c95eed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ca500a1c-02d9-4e45-97ac-0425c8c95eed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->