### PR TITLE
♻️ refactor: derive bot runtime defaults from config

### DIFF
--- a/marrow_core/cli.py
+++ b/marrow_core/cli.py
@@ -847,6 +847,7 @@ def install_service(
         core_dir=root.core_dir,
         service_config_path=resolve_service_config_path(platform, root.service.config_path),
         service_user=resolve_service_user(root),
+        agent_home=root.agents[0].home,
         log_dir=resolve_service_log_dir(root),
     )
     written = write_service_files(files, output_dir)

--- a/marrow_core/config.py
+++ b/marrow_core/config.py
@@ -2,12 +2,18 @@
 
 from __future__ import annotations
 
+import sys
 import tomllib
 import warnings
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field, field_validator, model_validator
+
+try:
+    import pwd
+except ImportError:  # pragma: no cover - non-Unix fallback
+    pwd = None
 
 
 def _clamp(value: int, lo: int, hi: int, name: str) -> int:
@@ -17,6 +23,18 @@ def _clamp(value: int, lo: int, hi: int, name: str) -> int:
     return clamped
 
 
+def _default_home_for_user(user: str) -> str:
+    if not user:
+        return ""
+    if pwd is not None:
+        try:
+            return pwd.getpwnam(user).pw_dir
+        except KeyError:
+            pass
+    base = "/Users" if sys.platform == "darwin" else "/home"
+    return f"{base}/{user}"
+
+
 class AgentConfig(BaseModel):
     """Single scheduled agent definition."""
 
@@ -24,7 +42,7 @@ class AgentConfig(BaseModel):
     heartbeat_interval: int = 300
     heartbeat_timeout: int = 500
     agent_command: str
-    workspace: str  # Agent's writable workspace root (e.g. /Users/marrow)
+    workspace: str = ""  # Agent's writable workspace root (e.g. /Users/marrow)
     user: str = Field(default="", validation_alias=AliasChoices("user", "run_as_user"))
     run_as_group: str = ""
     home: str = ""
@@ -67,7 +85,7 @@ class AgentConfig(BaseModel):
     @field_validator("workspace")
     @classmethod
     def _abs_workspace(cls, v: str) -> str:
-        if not Path(v).is_absolute():
+        if v and not Path(v).is_absolute():
             raise ValueError(f"workspace must be absolute: {v}")
         return v
 
@@ -81,7 +99,13 @@ class AgentConfig(BaseModel):
     @model_validator(mode="after")
     def _default_home(self) -> AgentConfig:
         if not self.home and self.user:
-            self.home = f"/Users/{self.user}"
+            self.home = _default_home_for_user(self.user)
+        if not self.workspace and self.home:
+            self.workspace = self.home
+        if not self.workspace:
+            raise ValueError("workspace must be set or derivable from user/home")
+        if not self.context_dirs:
+            self.context_dirs = [str(Path(self.workspace) / "context.d")]
         return self
 
     @field_validator("context_dirs", mode="before")
@@ -146,7 +170,7 @@ class SelfCheckConfig(BaseModel):
 
     enabled: bool = True
     interval_seconds: int = 900
-    wake_agent: str = "orchestrator"
+    wake_agent: str = ""
     extra_commands: list[str] = Field(default_factory=list)
 
     model_config = ConfigDict(extra="forbid")
@@ -202,12 +226,114 @@ class ServiceConfig(BaseModel):
         return v
 
 
+class PluginConfig(BaseModel):
+    """Hosted plugin/background-service definition."""
+
+    name: str
+    kind: Literal["dashboard", "background_service"] = "background_service"
+    command: str
+    args: list[str] = Field(default_factory=list)
+    enabled: bool = True
+    auto_start: bool = False
+    cwd: str = ""
+    workspace: str = ""
+    config_path: str = ""
+    capabilities: list[str] = Field(default_factory=list)
+    env: dict[str, str] = Field(default_factory=dict)
+
+    model_config = ConfigDict(extra="forbid")
+
+    @field_validator("name", "command", mode="before")
+    @classmethod
+    def _strip_required_fields(cls, v: Any) -> str:
+        value = str(v).strip()
+        if not value:
+            raise ValueError("plugin field must not be empty")
+        return value
+
+    @field_validator("cwd", "workspace", "config_path", mode="before")
+    @classmethod
+    def _strip_optional_paths(cls, v: Any) -> str:
+        return str(v).strip() if v is not None else ""
+
+    @field_validator("cwd", "workspace", "config_path")
+    @classmethod
+    def _abs_optional_paths(cls, v: str) -> str:
+        if v and not Path(v).is_absolute():
+            raise ValueError(f"plugin path must be absolute: {v}")
+        return v
+
+    @field_validator("args", "capabilities", mode="before")
+    @classmethod
+    def _normalize_list_fields(cls, v: Any) -> list[str]:
+        if v is None:
+            return []
+        if isinstance(v, str):
+            return [v.strip()] if v.strip() else []
+        return [str(item).strip() for item in v if str(item).strip()]
+
+    @field_validator("env", mode="before")
+    @classmethod
+    def _normalize_env(cls, v: Any) -> dict[str, str]:
+        if v is None:
+            return {}
+        if not isinstance(v, dict):
+            raise ValueError("plugin env must be a table/object")
+        return {str(key): str(value) for key, value in v.items()}
+
+
+class ProfileConfig(BaseModel):
+    """Optional external profile bundle paths."""
+
+    root_dir: str = ""
+    rules_path: str = ""
+    source_context_dir: str = ""
+
+    model_config = ConfigDict(extra="forbid")
+
+    @field_validator("root_dir", "rules_path", "source_context_dir", mode="before")
+    @classmethod
+    def _strip_optional_paths(cls, v: Any) -> str:
+        return str(v).strip() if v is not None else ""
+
+    @model_validator(mode="after")
+    def _resolve_paths(self) -> ProfileConfig:
+        root = Path(self.root_dir) if self.root_dir else None
+        if root is not None and not root.is_absolute():
+            raise ValueError(f"profile.root_dir must be absolute: {self.root_dir}")
+
+        defaults = {
+            "source_context_dir": "context.d",
+        }
+
+        if root is not None:
+            self.root_dir = str(root)
+
+        for field_name, default_rel in defaults.items():
+            raw = getattr(self, field_name)
+            if not raw and root is not None:
+                raw = str(root / default_rel)
+            if not raw:
+                continue
+            path = Path(raw)
+            if not path.is_absolute():
+                if root is None:
+                    raise ValueError(
+                        f"profile.{field_name} must be absolute without profile.root_dir: {raw}"
+                    )
+                path = root / raw
+            setattr(self, field_name, str(path))
+        return self
+
+
 class RootConfig(BaseModel):
     """Top-level marrow.toml schema."""
 
-    core_dir: str = "/opt/marrow-core"
+    core_dir: str = ""
+    profile: ProfileConfig = Field(default_factory=ProfileConfig)
     service: ServiceConfig = Field(default_factory=ServiceConfig)
     agents: list[AgentConfig] = Field(default_factory=list)
+    plugins: list[PluginConfig] = Field(default_factory=list)
     ipc: IpcConfig = Field(default_factory=IpcConfig)
     sync: SyncConfig = Field(default_factory=SyncConfig)
     self_check: SelfCheckConfig = Field(default_factory=SelfCheckConfig)
@@ -216,6 +342,8 @@ class RootConfig(BaseModel):
 
     @model_validator(mode="after")
     def _validate_supervisor_agents(self) -> RootConfig:
+        if not self.self_check.wake_agent and self.agents:
+            self.self_check.wake_agent = self.agents[0].name
         if self.service.mode != "supervisor":
             return self
         for agent in self.agents:

--- a/marrow_core/ipc.py
+++ b/marrow_core/ipc.py
@@ -15,15 +15,26 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import json
+import os
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Protocol
 
 from loguru import logger
 
 from marrow_core.task_queue import create_task_file, list_tasks
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from marrow_core.heartbeat import HeartbeatState
+
+
+class _WakeHandle(Protocol):
+    def set(self) -> None: ...
+
+
+class _StateView(Protocol):
+    def to_dict(self) -> dict[str, Any]: ...
 
 
 # ---------------------------------------------------------------------------
@@ -66,8 +77,8 @@ async def _handle(
     reader: asyncio.StreamReader,
     writer: asyncio.StreamWriter,
     task_dir: Path,
-    state: HeartbeatState,
-    wake_events: dict[str, asyncio.Event],
+    state: _StateView,
+    wake_events: Mapping[str, _WakeHandle],
     *,
     task_submitter=None,
     task_lister=None,
@@ -173,8 +184,8 @@ async def _handle(
 async def start_ipc_server(
     socket_path: str,
     task_dir: str,
-    state: HeartbeatState,
-    wake_events: dict[str, asyncio.Event],
+    state: _StateView,
+    wake_events: Mapping[str, _WakeHandle],
     *,
     task_submitter=None,
     task_lister=None,
@@ -187,6 +198,9 @@ async def start_ipc_server(
         sock.unlink()
 
     td = Path(task_dir)
+    td.mkdir(parents=True, exist_ok=True)
+    with contextlib.suppress(PermissionError):
+        os.chmod(td, 0o770)
 
     async def handler(r: asyncio.StreamReader, w: asyncio.StreamWriter) -> None:
         await _handle(
@@ -200,5 +214,7 @@ async def start_ipc_server(
         )
 
     server = await asyncio.start_unix_server(handler, path=str(sock))
+    with contextlib.suppress(PermissionError):
+        os.chmod(sock, 0o660)
     logger.info("ipc server listening on {}", sock)
     return server

--- a/marrow_core/runtime.py
+++ b/marrow_core/runtime.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import shutil
 from pathlib import Path
 
 from marrow_core.config import RootConfig
@@ -81,7 +82,32 @@ def resolve_task_dir(root: RootConfig) -> str:
 
 
 def marrow_binary(core_dir: str) -> str:
+    if not core_dir:
+        return shutil.which("marrow-core") or shutil.which("marrow") or "marrow-core"
     return str(Path(core_dir) / ".venv" / "bin" / "marrow")
+
+
+def build_service_path(home_dir: str = "") -> str:
+    parts: list[str] = []
+    if home_dir:
+        home = Path(home_dir)
+        parts.extend(
+            [
+                str(home / ".bun" / "bin"),
+                str(home / ".local" / "bin"),
+                str(home / "bin"),
+            ]
+        )
+    parts.extend(DEFAULT_SERVICE_PATH.split(":"))
+
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for part in parts:
+        if not part or part in seen:
+            continue
+        seen.add(part)
+        ordered.append(part)
+    return ":".join(ordered)
 
 
 def resolve_sync_state_path(root: RootConfig) -> str:

--- a/marrow_core/services.py
+++ b/marrow_core/services.py
@@ -6,7 +6,7 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
-from marrow_core.runtime import DEFAULT_SERVICE_PATH, marrow_binary
+from marrow_core.runtime import build_service_path, marrow_binary
 
 
 @dataclass(frozen=True)
@@ -38,6 +38,7 @@ def render_service_files(
     core_dir: str,
     service_config_path: str,
     service_user: str,
+    agent_home: str,
     log_dir: str,
 ) -> list[ServiceFile]:
     target = detect_service_platform(platform)
@@ -46,12 +47,14 @@ def render_service_files(
             core_dir=core_dir,
             service_config_path=service_config_path,
             service_user=service_user,
+            agent_home=agent_home,
             log_dir=log_dir,
         )
     return _render_systemd_files(
         core_dir=core_dir,
         service_config_path=service_config_path,
         service_user=service_user,
+        agent_home=agent_home,
         log_dir=log_dir,
     )
 
@@ -71,11 +74,13 @@ def _render_launchd_files(
     core_dir: str,
     service_config_path: str,
     service_user: str,
+    agent_home: str,
     log_dir: str,
 ) -> list[ServiceFile]:
     binary = marrow_binary(core_dir)
     config = service_config_path
-    path_env = DEFAULT_SERVICE_PATH
+    path_env = build_service_path(agent_home)
+    working_dir = core_dir or "/tmp"
     username_block = ""
     if service_user:
         username_block = f"  <key>UserName</key>\n  <string>{service_user}</string>\n\n"
@@ -103,7 +108,7 @@ def _render_launchd_files(
                 f"    <key>PATH</key><string>{path_env}</string>\n"
                 "  </dict>\n\n"
                 "  <key>WorkingDirectory</key>\n"
-                f"  <string>{core_dir}</string>\n\n"
+                f"  <string>{working_dir}</string>\n\n"
                 f"{username_block}"
                 "  <key>KeepAlive</key>\n"
                 "  <true/>\n\n"
@@ -123,11 +128,14 @@ def _render_systemd_files(
     core_dir: str,
     service_config_path: str,
     service_user: str,
+    agent_home: str,
     log_dir: str,
 ) -> list[ServiceFile]:
     binary = marrow_binary(core_dir)
     config = service_config_path
     user_line = f"User={service_user}\n" if service_user else ""
+    working_dir = core_dir or "/tmp"
+    path_env = build_service_path(agent_home)
     return [
         ServiceFile(
             name="marrow-heart.service",
@@ -138,8 +146,8 @@ def _render_systemd_files(
                 "[Service]\n"
                 "Type=simple\n"
                 f"{user_line}"
-                f"WorkingDirectory={core_dir}\n"
-                f"Environment=PATH={DEFAULT_SERVICE_PATH}\n"
+                f"WorkingDirectory={working_dir}\n"
+                f"Environment=PATH={path_env}\n"
                 f"ExecStart={binary} run --config {config} --json-logs\n"
                 "Restart=always\n"
                 "RestartSec=5\n"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -328,6 +328,38 @@ def test_install_service_renders_units(monkeypatch, tmp_path: Path) -> None:
     assert "rendered 1 service file(s)" in result.stdout
 
 
+def test_install_service_uses_configured_service_config_path(tmp_path: Path) -> None:
+    config = _write_config(tmp_path)
+    output_dir = tmp_path / "service-out"
+    text = config.read_text(encoding="utf-8").replace(
+        '[service]\nmode = "single_user"\nruntime_root = '
+        + json.dumps(str(tmp_path / "service-runtime")),
+        '[service]\nmode = "single_user"\nruntime_root = '
+        + json.dumps(str(tmp_path / "service-runtime"))
+        + '\nconfig_path = "/opt/marrow-bot/marrow.toml"',
+        1,
+    )
+    config.write_text(text, encoding="utf-8")
+
+    result = runner.invoke(
+        app,
+        [
+            "install-service",
+            "--config",
+            str(config),
+            "--platform",
+            "linux",
+            "--output-dir",
+            str(output_dir),
+        ],
+    )
+
+    service_text = (output_dir / "marrow-heart.service").read_text(encoding="utf-8")
+
+    assert result.exit_code == 0
+    assert "--config /opt/marrow-bot/marrow.toml --json-logs" in service_text
+
+
 def test_sync_once_reports_noop(monkeypatch, tmp_path: Path) -> None:
     config = _write_config(tmp_path)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import pytest
 from pydantic import ValidationError
 
-from marrow_core.config import AgentConfig, ServiceConfig, load_config
+from marrow_core.config import AgentConfig, PluginConfig, ServiceConfig, load_config
 
 
 def test_empty_name_raises():
@@ -60,12 +60,15 @@ def test_service_mode_rejects_unknown() -> None:
         ServiceConfig(mode="other")
 
 
+def test_plugin_requires_absolute_paths() -> None:
+    with pytest.raises(ValueError, match="absolute"):
+        PluginConfig(name="dashboard", kind="dashboard", command="python", cwd="relative/path")
+
+
 def test_load_config(tmp_path: Path):
     toml = tmp_path / "marrow.toml"
     toml.write_text(
         textwrap.dedent("""\
-        core_dir = "/opt/marrow-core"
-
         [service]
         mode = "supervisor"
         runtime_root = "/var/lib/marrow"
@@ -76,6 +79,13 @@ def test_load_config(tmp_path: Path):
         agent_command = "opencode run --agent orchestrator"
         workspace = "/Users/marrow"
         context_dirs = ["/Users/marrow/context.d"]
+
+        [[plugins]]
+        name = "dashboard"
+        kind = "dashboard"
+        command = "python"
+        args = ["-m", "marrow_dashboard", "serve"]
+        workspace = "/Users/marrow"
     """)
     )
     root = load_config(toml)
@@ -84,9 +94,39 @@ def test_load_config(tmp_path: Path):
     assert root.agents[0].user == "marrow"
     assert root.agents[0].home == "/Users/marrow"
     assert root.service.mode == "supervisor"
-    assert root.core_dir == "/opt/marrow-core"
+    assert root.core_dir == ""
     assert root.ipc.enabled is True
     assert root.self_check.enabled is True
+    assert len(root.plugins) == 1
+    assert root.plugins[0].name == "dashboard"
+
+
+def test_load_config_defaults_workspace_and_context_from_user(tmp_path: Path) -> None:
+    toml = tmp_path / "marrow.toml"
+    toml.write_text(
+        textwrap.dedent("""\
+        [profile]
+        root_dir = "/opt/marrow-bot"
+
+        [service]
+        mode = "single_user"
+        config_path = "/opt/marrow-bot/marrow.toml"
+
+        [[agents]]
+        user = "marrow"
+        name = "orchestrator"
+        agent_command = "opencode run --agent orchestrator"
+    """)
+    )
+
+    root = load_config(toml)
+
+    assert root.profile.root_dir == "/opt/marrow-bot"
+    assert root.profile.source_context_dir == "/opt/marrow-bot/context.d"
+    assert root.service.config_path == "/opt/marrow-bot/marrow.toml"
+    assert root.agents[0].workspace.endswith("/marrow")
+    assert root.agents[0].agent_command == "opencode run --agent orchestrator"
+    assert root.agents[0].context_dirs == ["/Users/marrow/context.d"]
 
 
 def test_extra_forbid(tmp_path: Path):

--- a/tests/test_ipc.py
+++ b/tests/test_ipc.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import shutil
+import stat
 import tempfile
 from pathlib import Path
 
@@ -175,6 +177,16 @@ async def test_list_tasks_after_add(ipc_server):
     data = await _ipc_request(sock, "GET", "/tasks")
     assert len(data["tasks"]) == 1
     assert data["tasks"][0]["title"] == "alpha"
+
+
+async def test_ipc_socket_and_task_dir_are_user_writable(ipc_server):
+    sock, task_dir, _, _ = ipc_server
+
+    sock_mode = stat.S_IMODE(os.stat(sock).st_mode)
+    task_dir_mode = stat.S_IMODE(task_dir.stat().st_mode)
+
+    assert sock_mode == 0o660
+    assert task_dir_mode == 0o770
 
 
 async def test_not_found(ipc_server):

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from marrow_core.config import RootConfig
 from marrow_core.runtime import (
+    build_service_path,
     marrow_binary,
     resolve_socket_path,
     resolve_task_dir,
@@ -51,3 +52,18 @@ def test_runtime_paths_respect_ipc_overrides() -> None:
 
 def test_marrow_binary_uses_core_virtualenv() -> None:
     assert marrow_binary("/opt/marrow-core") == "/opt/marrow-core/.venv/bin/marrow"
+
+
+def test_marrow_binary_falls_back_to_cli_entrypoint() -> None:
+    assert (
+        marrow_binary("") in {"marrow-core", "marrow"}
+        or marrow_binary("").endswith("marrow-core")
+        or marrow_binary("").endswith("marrow")
+    )
+
+
+def test_build_service_path_prefers_user_bins() -> None:
+    path = build_service_path("/Users/marrow")
+
+    assert path.startswith("/Users/marrow/.bun/bin:/Users/marrow/.local/bin:/Users/marrow/bin:")
+    assert "/usr/bin" in path

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -14,11 +14,13 @@ def test_render_launchd_service_files_include_path_and_logs() -> None:
         core_dir="/opt/marrow-core",
         service_config_path=resolve_service_config_path("darwin"),
         service_user="",
+        agent_home="/Users/marrow",
         log_dir="/var/lib/marrow/logs",
     )
 
     assert [file.name for file in files] == ["com.marrow.heart.plist"]
     assert "EnvironmentVariables" in files[0].content
+    assert "/Users/marrow/.bun/bin" in files[0].content
     assert "/var/lib/marrow/logs/heart.stdout.log" in files[0].content
     assert "/Library/Application Support/marrow/marrow.toml" in files[0].content
     assert "UserName" not in files[0].content
@@ -30,6 +32,7 @@ def test_render_systemd_service_files_only_include_primary_unit() -> None:
         core_dir="/opt/marrow-core",
         service_config_path=resolve_service_config_path("linux"),
         service_user="marrow",
+        agent_home="/Users/marrow",
         log_dir="/Users/marrow/runtime/logs",
     )
 
@@ -37,5 +40,9 @@ def test_render_systemd_service_files_only_include_primary_unit() -> None:
     assert (
         "ExecStart=/opt/marrow-core/.venv/bin/marrow run "
         "--config /etc/marrow/marrow.toml --json-logs" in files[0].content
+    )
+    assert (
+        "Environment=PATH=/Users/marrow/.bun/bin:/Users/marrow/.local/bin:/Users/marrow/bin:"
+        in files[0].content
     )
     assert "User=marrow" in files[0].content


### PR DESCRIPTION
## Summary
- let runtime config derive workspace, context dir, and agent home from the configured bot user instead of hard-coded per-machine paths
- render service PATH entries that include user-local bins so `opencode` can be discovered without checking in a workstation-specific absolute path
- tighten IPC permissions so the task socket and queue remain usable for non-root task add/list flows